### PR TITLE
PAAS-1535: fix karaf password when containing dollar sign

### DIFF
--- a/assets/jcustomer/reset-unomi-root-password.py
+++ b/assets/jcustomer/reset-unomi-root-password.py
@@ -6,21 +6,22 @@ from binascii import a2b_base64
 import re
 import os.path
 
+new_password_b64 = sys.argv[1]
 new_password = a2b_base64(str.encode(sys.argv[1])).decode("utf-8")
 unomi_env_file = sys.argv[2]
 datadog_conf_file = sys.argv[3]
 
 pwd_set = False
-password_line = "export UNOMI_ROOT_PASSWORD=" + new_password
+password_line = f'UNOMI_ROOT_PASSWORD_B64="{new_password_b64}"\n'
+export_password_line = "export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)"
 with fileinput.FileInput(unomi_env_file, inplace=True) as file:
     for line in file:
-        if "UNOMI_ROOT_PASSWORD" in line:
-            line = password_line
-            pwd_set = True
+        if "UNOMI_ROOT_PASSWORD_B64=" in line or "export UNOMI_ROOT_PASSWORD=" in line:
+            continue
         print(line, end='')
-if not pwd_set:
-    with open(unomi_env_file, "a") as file:
-        file.write(password_line)
+
+with open(unomi_env_file, 'a') as file:
+    file.write(password_line + export_password_line)
 
 if not os.path.exists(datadog_conf_file):
     exit(0)

--- a/assets/jcustomer/reset-unomi-root-password.py
+++ b/assets/jcustomer/reset-unomi-root-password.py
@@ -13,7 +13,7 @@ datadog_conf_file = sys.argv[3]
 
 pwd_set = False
 password_line = f'UNOMI_ROOT_PASSWORD_B64="{new_password_b64}"\n'
-export_password_line = "export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)"
+export_password_line = "export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)\n"
 with fileinput.FileInput(unomi_env_file, inplace=True) as file:
     for line in file:
         if "UNOMI_ROOT_PASSWORD_B64=" in line or "export UNOMI_ROOT_PASSWORD=" in line:

--- a/mixins/jcustomer.yml
+++ b/mixins/jcustomer.yml
@@ -134,6 +134,7 @@ actions:
           echo "export UNOMI_CLUSTER_INTERNAL_ADDRESS=${@i.url}:9443" >> $envfile
           echo "UNOMI_ROOT_PASSWORD_B64=\"${this.unomi_root_password.toBase64()}\"" >> $envfile
           echo 'export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)' >> $envfile
+          echo >> $envfile
           systemctl is-active --quiet karaf && systemctl restart karaf || exit 0
         user: root
     - if ("${response.errOut}" != ""):

--- a/mixins/jcustomer.yml
+++ b/mixins/jcustomer.yml
@@ -16,7 +16,7 @@ actions:
             break
           }
         }
-        var cmd = "find -H /opt/ -mindepth 4  -type f -name setenv -exec awk -F'=' '$1~/ROOT_PASSWORD$/ {print $2}' {} \\;";
+        var cmd = "find -H /opt/ -mindepth 4  -type f -name setenv -exec awk -F'\"' '$1~/UNOMI_ROOT_PASSWORD_B64=$/ {print $2}' {} \\; | base64 -d";
         var command = toJSON([{"command": cmd}]);
         var res = jelastic.env.control.ExecCmdById(unomi_env_name, session, unomi_nodeid, command)
         var unomi_pwd = res['responses'][0]['out'];
@@ -47,7 +47,7 @@ actions:
     cmd [${this}]: |-
       if service karaf status > /dev/null; then
         setenv=$(find /opt/jcustomer/jcustomer/bin -name setenv)
-        karaf_pwd=$(grep UNOMI_ROOT_PASSWORD $setenv | cut -d"=" -f2 | sed 's,\s\+,,g')
+        karaf_pwd=$(awk -F'"' '$1~/UNOMI_ROOT_PASSWORD_B64=$/ {print $2}' $setenv | base64 -d)
         karaf_credentials="karaf:$karaf_pwd"
         curl -fsI /dev/null -u "$karaf_credentials" http://localhost:80/cxs/privacy/info && exit 0
       fi
@@ -57,7 +57,7 @@ actions:
   saveUnomiRootPassword:
     - cmd [${nodes.cp.first.id}]: |-
         setenv=$(find /opt/jcustomer/jcustomer/bin -name setenv)
-        grep UNOMI_ROOT_PASSWORD $setenv | cut -d"=" -f2 | sed 's,\s\+,,g'
+        awk -F'"' '$1~/UNOMI_ROOT_PASSWORD_B64=$/ {print $2}' $setenv | base64 -d
     - environment.control.ApplyNodeGroupData[cp]:
         data:
           temp_unomi_root_password: ${response.out}
@@ -80,7 +80,7 @@ actions:
     - setGlobalRepoRootUrl
     - forEach(nodes.${this.target}):
         cmd[${@i.id}]: |-
-          sed -i 's/\(password: \).*/\1${this.unomi_root_password}/' /etc/datadog-agent/conf.d/jmx.d/conf.yaml
+          sed -i "s/\(password: \).*/\1$(echo ${this.unomi_root_password.toBase64()} | base64 -d)/" /etc/datadog-agent/conf.d/jmx.d/conf.yaml
           mkdir /etc/datadog-agent/conf.d/jelastic.d /var/log/jelastic-packages
           chown root:root /var/log/jelastic-packages
           chown dd-agent: /etc/datadog-agent/conf.d/jelastic.d
@@ -132,7 +132,8 @@ actions:
               -i $envfile
           echo "export UNOMI_CLUSTER_PUBLIC_ADDRESS=${@i.url}" >> $envfile
           echo "export UNOMI_CLUSTER_INTERNAL_ADDRESS=${@i.url}:9443" >> $envfile
-          echo "export UNOMI_ROOT_PASSWORD=${this.unomi_root_password}" >> $envfile
+          echo "UNOMI_ROOT_PASSWORD_B64=\"${this.unomi_root_password.toBase64()}\"" >> $envfile
+          echo 'export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)' >> $envfile
           systemctl is-active --quiet karaf && systemctl restart karaf || exit 0
         user: root
     - if ("${response.errOut}" != ""):
@@ -201,7 +202,7 @@ actions:
     cmd [${this}]: |-
         log_file="/var/log/jelastic-packages/checkJcustomerHealthWhenStarting"
         setenv=$(find /opt/jcustomer/jcustomer/bin -name setenv)
-        karaf_pwd=$(grep UNOMI_ROOT_PASSWORD $setenv | cut -d"=" -f2 | sed 's,\s\+,,g')
+        karaf_pwd=$(awk -F'"' '$1~/UNOMI_ROOT_PASSWORD_B64=$/ {print $2}' $setenv | base64 -d)
         timeout=120
         echo "Jcustomer is starting...." >> $log_file
         echo "Waiting for cxs/privacy/info to be ok" >> $log_file
@@ -243,7 +244,7 @@ actions:
             data = {
               "targetAppid": jahiaEnvname,
               "settings": {"pwd": "${this.new_password}"},
-              "manifest": "${globals.repoRootUrl}/package/jahia/set-jcustomer-password-in-jahia.yml"
+              "manifest": "${globals.repoRootUrl}/packages/jahia/set-jcustomer-password-in-jahia.yml"
             };
             res += res + jelastic.dev.scripting.eval("appstore", session, "InstallApp", data);
           }

--- a/packages/jahia/link-to-jcustomer.yml
+++ b/packages/jahia/link-to-jcustomer.yml
@@ -11,6 +11,7 @@ description:
 mixins:
   - ../../mixins/common.yml
   - ../../mixins/jahia.yml
+  - ../../mixins/jcustomer.yml
 
 
 onInstall:
@@ -18,8 +19,10 @@ onInstall:
   - environment.control.ApplyNodeGroupData[proc, cp]:
       data:
         envLink: ${settings.unomienv}
+  - getUnomiDnsAndPwd:
+      unomi_env_name: ${settings.unomienv}
+  - getJahiaVersion
   - allowIP
-  - getUnomiDNSandPwd
   - upgradeJahiaModule:
       module: jExperience
       version: ${globals.jexperience_version}
@@ -57,27 +60,6 @@ actions:
           return {'result': new_prop.result, 'new_prop': new_prop};
 
   allowIP:
-    - script: |
-        const unomi_env_name = "${settings.unomienv}";
-        const nodes_infos = jelastic.env.control.GetEnvInfo(
-                unomi_env_name,
-                session
-              ).nodes;
-        const node_id = nodes_infos.filter(function (node) {
-                          return node.nodeGroup == "cp";
-                        }).pop().id;
-        const container_env_vars = jelastic.env.control.GetContainerEnvVars(
-                                     unomi_env_name,
-                                     session,
-                                     node_id
-                                   );
-        const allowed_ips = container_env_vars.object.UNOMI_THIRDPARTY_PROVIDER1_IPADDRESSES;
-
-        return allowed_ips === undefined?
-          {"result": 0, "value": ""} :
-          {"result": 0, "value": allowed_ips};
-    - setGlobals:
-        unomi_allowed_ips: ${response.value}
     - script: |
         var resp = jelastic.env.control.GetEnvInfo('${env.envName}', session);
         if (resp.result != 0) return resp;
@@ -120,28 +102,6 @@ actions:
         return {"result": 0}
     - log: "## unomi nodes get order to restart"
 
-  getUnomiDNSandPwd:
-    - script: |
-        var resp = jelastic.env.control.GetEnvInfo('${settings.unomienv}', session)
-        for (var i = 0, g = resp.nodes; i < g.length; i++) {
-          if (g[i].nodeGroup == "cp") {
-            var unomi_nodeid = g[i].id
-            var unomi_version = g[i].version.split("-", 1)[0]
-            break
-          }
-        }
-        var cmd = "find -H /opt/ -mindepth 4  -type f -name setenv -exec awk -F'=' '$1~/ROOT_PASSWORD$/ {print $2}' {} \\;"
-        var command = toJSON([{"command": cmd}])
-        var res = jelastic.env.control.ExecCmdById('${settings.unomienv}', session, unomi_nodeid, command)
-        var unomi_pwd = res['responses'][0]['out']
-        return {'result': 0, 'domain': resp.env.domain, 'unomi_pwd': unomi_pwd, 'unomi_version': unomi_version}
-    - setGlobals:
-        unomidns: ${response.domain}
-        unomi_pwd: ${response.unomi_pwd}
-        unomi_version: ${response.unomi_version}
-
-    - getJahiaVersion
-
     # Get jExperience version to install according to Jahia env version:
     # - Jahia 7.3.x ==> jExperience 1.11.4
     # - Jahia 8 < 8.0.2 ==> jExperience 1.12.2
@@ -175,7 +135,7 @@ actions:
         wget -qO - ${globals.repoRootUrl}/assets/jahia/$CONF_FILENAME \
         | sed -r -e 's;(\w+URL\s*=\s*).*;\1http://${globals.unomidns};' \
                    -e "s;[ #]*(\w+\.jCustomerKey\s*=\s*).*;\1${jcustomer_key};" \
-                   -e 's;(\w+Password\s*=\s*).*;\1${globals.unomi_pwd};' \
+                   -e "s;(\w+Password\s*=\s*).*;\1$(echo ${globals.unomi_pwd.toBase64()} | base64 -d);" \
                 > $CONF_PATH
         chown tomcat:tomcat "$CONF_PATH"
     - if ("${response.errOut}" != ""):

--- a/packages/jcustomer/install.yml
+++ b/packages/jcustomer/install.yml
@@ -13,7 +13,7 @@ description:
     privacy rules (such as GDPR).
 
 globals:
-  jcustomer_env_version: 3
+  jcustomer_env_version: 4
   unomi_version: ${settings.productVersion}
   unomi_root_password: ${fn.password(20)}
 ssl: true

--- a/packages/jcustomer/migrations/migrate-to-v4.yaml
+++ b/packages/jcustomer/migrations/migrate-to-v4.yaml
@@ -46,3 +46,4 @@ actions:
       sed -i "/$pmatch/d" $setenv
       echo "UNOMI_ROOT_PASSWORD_B64=\"$(echo $karaf_pwd | base64)\"" >> $setenv
       echo 'export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)' >> $setenv
+      echo >> $setenv

--- a/packages/jcustomer/migrations/migrate-to-v4.yaml
+++ b/packages/jcustomer/migrations/migrate-to-v4.yaml
@@ -1,0 +1,48 @@
+---
+type: update
+version: 1.5.2
+name: Migrate jCustomer env to v4
+id: migrate-jcustomer-env-v4
+
+# Required for healthchecks
+mixins:
+  - "../../../mixins/common.yml"
+  - "../../../mixins/elasticsearch.yml"
+  - "../../../mixins/jcustomer.yml"
+
+globals:
+  version: 4
+
+onInstall:
+  ### Pre-checks
+  - checkEnvVersion: ${globals.version}
+  - checkJcustomerHealth: cp
+  - checkEsClusterStatus
+  - eventsUpdate
+
+  - fixKarafPassword # PAAS-1535
+
+  ### Post-actions
+  - setEnvVersion: ${globals.version}
+  - logEvent:
+      target: ${nodes.cp.first.id}
+      title: "Environment $envName migrated"
+      text: "Environment $envName migrated to v${globals.version}"
+  - checkJcustomerHealth: cp
+  - checkEsClusterStatus
+
+actions:
+  eventsUpdate:
+    install:
+      jps: "${baseUrl}/../update-events.yml"
+
+  fixKarafPassword:
+    cmd [cp]: |-
+      setenv=$(find /opt/jcustomer/jcustomer/bin -name setenv)
+      pmatch="export UNOMI_ROOT_PASSWORD"
+      grep -q UNOMI_ROOT_PASSWORD_B64 $setenv && exit 0
+      karaf_pwd=$(awk -v "pmatch=$pmatch" -F"=" '$1==pmatch {print $2}' $setenv)
+      [ "$karaf_pwd" = "" ] && echo "[ERROR] Can't retrieve karaf password, aborting" && exit 1
+      sed -i "/$pmatch/d" $setenv
+      echo "UNOMI_ROOT_PASSWORD_B64=\"$(echo $karaf_pwd | base64)\"" >> $setenv
+      echo 'export UNOMI_ROOT_PASSWORD=$(echo $UNOMI_ROOT_PASSWORD_B64 | base64 -d)' >> $setenv


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1535

Short description:
I tried to think of a simple way to do it but it was more complex than it seemed because of the `export` command in `setenv` file.
The way I choose to go with allow the user to put single/double quotes, dollar signs and other special characters in their jcustomer password.
I've tested some scenarios and it seems to work pretty well