### PR TITLE
PAAS-1601: Escape backslashes inside jexperience cfg file

### DIFF
--- a/assets/jahia/update-jcustomer-password-in-jahia.py
+++ b/assets/jahia/update-jcustomer-password-in-jahia.py
@@ -2,18 +2,14 @@
 
 import fileinput
 import sys
-from os import urandom
-from hashlib import pbkdf2_hmac
-from binascii import b2a_base64, a2b_base64
+from binascii import a2b_base64
 
 file_path = sys.argv[1]
-new_password = new_password = a2b_base64(str.encode(sys.argv[2])).decode("utf-8")
+new_password = a2b_base64(str.encode(sys.argv[2])).decode("utf-8")
 
 with fileinput.FileInput(file_path, inplace=True, backup='.bak') as file:
     for line in file:
         if 'jexperience.jCustomerPassword' in line:
             line = "jexperience.jCustomerPassword=" + new_password + "\n"
-        elif 'mf.unomiPassword' in line:
-            line = "mf.unomiPassword=" + new_password + "\n"
 
         print(line, end='')

--- a/assets/jahia/update-jcustomer-password-in-jahia.py
+++ b/assets/jahia/update-jcustomer-password-in-jahia.py
@@ -7,6 +7,11 @@ from binascii import a2b_base64
 file_path = sys.argv[1]
 new_password = a2b_base64(str.encode(sys.argv[2])).decode("utf-8")
 
+# We need to escape backslashes (with a backslash) before writing to the cfg file
+new_password = new_password.translate(str.maketrans(
+    {"\\": r"\\"},
+))
+
 with fileinput.FileInput(file_path, inplace=True, backup='.bak') as file:
     for line in file:
         if 'jexperience.jCustomerPassword' in line:

--- a/packages/jahia/link-to-jcustomer.yml
+++ b/packages/jahia/link-to-jcustomer.yml
@@ -134,10 +134,12 @@ actions:
         CONF_PATH="/data/digital-factory-data/karaf/etc/$CONF_FILENAME"
         # Set up jExperience configuration
         jcustomer_key=${globals.jcustomerKey}
+        # The last sed is required to escape backslashes (with a backslash) inside the cfg file
         wget -qO - ${globals.repoRootUrl}/assets/jahia/$CONF_FILENAME \
         | sed -r -e 's;(\w+URL\s*=\s*).*;\1http://${globals.unomidns};' \
                    -e "s;[ #]*(\w+\.jCustomerKey\s*=\s*).*;\1${jcustomer_key};" \
                    -e "s;(\w+Password\s*=\s*).*;\1$(echo -n ${globals.unomi_pwd_b64} | base64 -d | sed 's;\\;\\\\;g');" \
+        | sed 's;\\;\\\\;g' \
                 > $CONF_PATH
         chown tomcat:tomcat "$CONF_PATH"
     - if ("${response.errOut}" != ""):

--- a/packages/jahia/set-jcustomer-password-in-jahia.yml
+++ b/packages/jahia/set-jcustomer-password-in-jahia.yml
@@ -21,6 +21,7 @@ onInstall:
       wget -O ${globals.script_path} ${globals.repoRootUrl}/assets/jahia/update-jcustomer-password-in-jahia.py
       chmod u+x ${globals.script_path}
       ${globals.script_path} "${globals.jexp_config_file}" "${settings.pwd_b64}"
+      chown tomcat: ${globals.jexp_config_file}
     user: root
 
 settings:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1601

Short description:
For example if the password is `Password\01`, we need to write `Password\\01` in the cfg file.