### PR TITLE
PAAS-1708: fix haproxy conf overwritten in migration-v8

### DIFF
--- a/packages/jahia/migrations/migrate-to-v8.yaml
+++ b/packages/jahia/migrations/migrate-to-v8.yaml
@@ -125,10 +125,10 @@ actions:
       vars:
         haproxy_cfg_timeout_server: "5m"
     - cmd[bl]: |-
-        HAPROXY_CONF_DIR=/etc/haproxy/haproxy.cfg.jahia
+        HAPROXY_CONF=/etc/haproxy/haproxy.cfg.jahia/jahia-cloud.cfg
         HAPROXY_SYSCONFIG=/etc/sysconfig/haproxy
         HAPROXY_RELOAD=/usr/local/bin/haproxy-reload.sh
-        curl -fLSso $HAPROXY_CONF_DIR/jahia-cloud.cfg ${globals.repoRootUrl}/assets/haproxy/haproxy-jahia-cloud.cfg || exit 1
+        sed -i -e 's;^\(\s*timeout server\s*\).*;\1"\${haproxy_cfg_timeout_server}";' $HAPROXY_CONF
         curl -fLSso $HAPROXY_SYSCONFIG ${globals.repoRootUrl}/assets/haproxy/haproxy-sysconfig || exit 1
         curl -fLSso $HAPROXY_RELOAD ${globals.repoRootUrl}/assets/haproxy/haproxy-reload.sh || exit 1
         chmod +x $HAPROXY_RELOAD


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1708

Short description:
The only update of jahia-cloud.cfg was the "timeout server" line so rather than overwriting the whole file, we can just sed