### PR TITLE
PAAS-1800: fix action to switch proxysql switch master

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -699,13 +699,11 @@ actions:
     # Return:
     #   - galeraMasterIndex
     - cmd[proc]: |-
-        ${globals.proxysql_cli} -BNe "select DISTINCT hostname from mysql_servers where weight = 1000"
+        ${globals.proxysql_cli} -BNe "select DISTINCT hostname from runtime_mysql_servers where weight = 1000"
     - setGlobals:
         - galeraMasterIndex: ${response.out}
 
   proxysqlSwitchMaster:
-    # !!!!!!!!!! This action is very unstable and must be used along with FRO !!!!!!!!!!!
-    # !!!!!!!!!! Will be fixed by https://jira.jahia.org/browse/PAAS-1800     !!!!!!!!!!!
     # Parameter:
     #   - target: galera number (1,2,3)
     - cmd[proc, cp]: |-
@@ -716,8 +714,10 @@ actions:
           exit 0
         fi
 
-    - cmd[proc]: |-
-        ${globals.proxysql_cli} -e "update mysql_servers set weight=1;"
+    - cmd[proc, cp]: |-
+        ${globals.proxysql_cli} -e "REPLACE INTO mysql_servers(hostgroup_id,hostname,port, max_connections, weight) VALUES (2,'galera_1',3306, 50, 1);"
+        ${globals.proxysql_cli} -e "REPLACE INTO mysql_servers(hostgroup_id,hostname,port, max_connections, weight) VALUES (2,'galera_2',3306, 50, 1);"
+        ${globals.proxysql_cli} -e "REPLACE INTO mysql_servers(hostgroup_id,hostname,port, max_connections, weight) VALUES (2,'galera_3',3306, 50, 1);"
         ${globals.proxysql_cli} -e "update mysql_servers set weight=1000 where hostname='galera_${this.target}';"
         ${globals.proxysql_cli} -e "LOAD MYSQL SERVERS TO RUNTIME;"
         ${globals.proxysql_cli} -e "SAVE MYSQL SERVERS TO DISK"
@@ -728,9 +728,10 @@ actions:
         res=$(${globals.proxysql_cli} -BNe "select * from runtime_mysql_servers where weight=1000 group by hostname;" | wc -l)
         if [ $res -lt 1 ];then
           echo "There is no master node with a weight of 1000 in proxysql runtime configuration" >> /var/log/jelastic-packages/proxySqlSwitchMaster.log
-          exit 0
+          exit 1
         elif [ $res -gt 1 ]; then
           echo "There is more than one master node with a weight of 1000 in proxysql runtime configuration" >> /var/log/jelastic-packages/proxySqlSwitchMaster.log
+          exit 1
         fi
 
     - cmd[sqldb]: |-
@@ -739,7 +740,7 @@ actions:
         if [[ "$my_node_name_index" == "galera_${this.target}" ]]; then
           exit 0
         fi
-        timeout=330 # wait for 3min30
+        timeout=600 # wait for 600s
         tries=0
         request="select COUNT(*) from INFORMATION_SCHEMA.PROCESSLIST where db='jahia' and user like 'jahia-db-%'"
         while [[ $(mysql -BNe "$request") -gt 0 ]]; do

--- a/packages/jahia/galera-restart-nodes.yml
+++ b/packages/jahia/galera-restart-nodes.yml
@@ -11,6 +11,4 @@ mixins:
   - ../../mixins/mariadb.yml
 
 onInstall:
-  - enableFullReadOnlyOnCluster
   - rollingRestartGaleraNodes
-  - disableFullReadOnlyOnCluster

--- a/packages/jahia/redeploy-galera-nodes.yml
+++ b/packages/jahia/redeploy-galera-nodes.yml
@@ -14,9 +14,7 @@ mixins:
   - ../../mixins/mariadb.yml
 
 onInstall:
-  - enableFullReadOnlyOnCluster
   - redeployGaleraClusterNodes
-  - disableFullReadOnlyOnCluster
 
 settings:
   fields:

--- a/packages/jahia/set-galera-master.yml
+++ b/packages/jahia/set-galera-master.yml
@@ -13,10 +13,8 @@ mixins:
   - ../../mixins/jahia.yml
 
 onInstall:
-  - enableFullReadOnlyOnCluster
   - proxysqlSwitchMaster:
         target: ${settings.nodeIndex}
-  - disableFullReadOnlyOnCluster
 
 settings:
   fields:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1800

Short description:
I could analyze what was happening on proxysql side after reproducing, run commands manually and see what was happening, and it turns out that the runtime_mysql_server was sort of stuck when trying to reset the weight to 1 for all galera nodes, but it works if we replace the entries in mysql_servers and then reapply the weight.

I've done a lot of tests while installing the perf test site and can't reproduce anymore so it's promising 🙏 