### PR TITLE
PAAS-1970: fix detection of non dedicated jcustomer envs

### DIFF
--- a/packages/jcustomer/migrations/migrate-to-v11.yaml
+++ b/packages/jcustomer/migrations/migrate-to-v11.yaml
@@ -238,7 +238,8 @@ actions:
 
   checkES4Jcustomer:
     - cmd[${nodes.cp.first.id}]: |-
-        prefix=${UNOMI_ELASTICSEARCH_INDEXPREFIX:-context}
+        prefix=$UNOMI_ELASTICSEARCH_INDEXPREFIX
+        [ -z $prefix ] && prefix="context-"
         if (curl -s "http://es:9200/_cat/indices?h=index" | grep -qv "$prefix"); then
           echo "not jc dedicated"
         else


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-1970

Short description:
The identification of jCustomer environments used for AS doesn't work because of the prefix being {{-context}} all the time:
https://github.com/Jahia/jelastic-packages/pull/288/files#diff-6444e82afd59550ec80adf6dbe1ed0df20dedb578c71bf46606489fdd8e669c6R203

This is due to... drum rolls... Jelastic! I think that {{${something:something_else}}} is going to check if something exists as a global or local variable, and if not it will use something_else, but before it is passed to the container to be executed (like global variables are replaced by their value for instance).
