### PR TITLE
PAAS-2109: add missing Datadog tracer jar in migration package

### DIFF
--- a/packages/jcustomer/migrations/migrate-to-v14.yaml
+++ b/packages/jcustomer/migrations/migrate-to-v14.yaml
@@ -48,6 +48,14 @@ actions:
       jps: "${baseUrl}/../update-events.yml"
 
   configureDatadogAPM:
+    - cmd [proc, cp]: |-
+        dd_dir=/opt/jcustomer/jcustomer/datadog
+        dd_file=$dd_dir/dd-java-agent.jar
+        [ -d  $dd_dir ] || mkdir $dd_dir
+        if [ ! -f $dd_file ]; then
+          curl -fSsLo $dd_file https://dtdg.co/latest-java-tracer || exit 1
+          chown karaf: -R /opt/jcustomer/jcustomer/datadog
+        fi
     - api: env.control.AddContainerEnvVars
       nodeGroup: cp
       vars: {"DATADOG_APM_ENABLED": "true"}


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2109

Short description:
