### PR TITLE
PAAS-2064: remove kibana-dashboards-provider and jexperience-dashboard when unlinking or deleting jCustomer

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -387,6 +387,7 @@ actions:
   removeKibanaDashboardAccountsAndSpace:
     # Parameters:
     #   - jCustomerEnv: Jcustomer env name in the env link of Jahia
+    - setGlobalRepoRootUrl
     - set:
         dashboardRoleAndAccountName: ${env.envName}-kibana-dashboard
         customerUserRoleAndAccountName: ${env.envName}-kibana-user
@@ -1821,6 +1822,16 @@ actions:
             }
           }
         );
+
+  removeKibanaAndJexperienceDashboards:
+  - uninstallModule:
+      moduleSymname: kibana-dashboards-provider
+  - uninstallModule:
+      moduleSymname: jexperience-dashboards
+  - cmd [proc]: |-
+      cfg_file=/data/digital-factory-data/karaf/etc/org.jahia.modules.kibana_dashboards_provider.cfg
+      sed -i "s,.*\(kibana_dashboards_provider.\)\(kibanaURL\|kibanaUser\|kibanaPassword\|kibanaSpace\).*,\1\2=,g" $cfg_file
+      sed -E 's:(^\s*kibana_dashboards_provider\.)(kibana(URL|User|Password|Space)).*:\1\2=:' -i $cfg_file
 
 ### Vault related actions ###
   vaultGetIPsecConfB64:

--- a/mixins/jcustomer.yml
+++ b/mixins/jcustomer.yml
@@ -165,42 +165,21 @@ actions:
         if (linkedJahiaEnvs.length == 0 || linkedJahiaEnvs == "null") {
           return {"result": 0, "out": "No jahia linked"};
         }
-        commands = [
-          {
-            "command": "sed -i 's/\\(jexperience.jCustomer.*=\\).*/\\1/g' /data/digital-factory-data/karaf/etc/org.jahia.modules.jexperience.settings-global.cfg"
-          }
-        ]
-
         linkedJahiaEnvs = linkedJahiaEnvs.split(',');
         unlinkedJahiaEnvs = [];
         res = "";
         linkedJahiaEnvs.forEach(
           function(jahiaEnvname) {
-            envInfos = jelastic.env.control.GetEnvInfo(jahiaEnvname, session);
-            ["cp","proc"].forEach(
-              function(nodeGroup) {
-                var resp = jelastic.env.nodegroup.ApplyData(jahiaEnvname, session,
-                  nodeGroup=nodeGroup,
-                  data={'envLink': null}
-                );
-                if (envInfos.env.status == 1)  {
-                  jelastic.env.control.ExecCmdByGroup(jahiaEnvname, session,
-                    nodeGroup=nodeGroup,
-                    commandList=toJSON(commands));
-                }
-              }
-            )
             resp = api.marketplace.jps.Install(
-              {
-                jps: "${globals.repoRootUrl}/packages/jahia/manage-module.yml",
-                envName: jahiaEnvname,
-                settings: {
-                  "action": "uninstall",
-                  "moduleName": "jexperience"
+                {
+                  jps: "${globals.repoRootUrl}/packages/jahia/unlink-jahia-jcustomer.yml",
+                  envName: jahiaEnvname,
+                  settings: {
+                    'isUnomiEnvDeletion': true,
+                    'jCustomerEnv': '${env.shortdomain}'
+                  }
                 }
-              }
             )
-            if (resp.result != 0) return resp;
             unlinkedJahiaEnvs.push(jahiaEnvname);
           }
         );

--- a/packages/jahia/link-to-jcustomer.yml
+++ b/packages/jahia/link-to-jcustomer.yml
@@ -162,6 +162,6 @@ settings:
   fields:
     - name: unomienv
       type: envlist
-      caption: Targeted Unomi env
+      caption: Target Unomi env
       required: true
       valueField: shortdomain

--- a/packages/jahia/unlink-jahia-jcustomer.yml
+++ b/packages/jahia/unlink-jahia-jcustomer.yml
@@ -13,11 +13,26 @@ mixins:
   - ../../mixins/jahia.yml
 
 onInstall:
-  - getJcustomer
+  - if ("${settings.jCustomerEnv.print()}" == ""):
+    - getJcustomer
+  - else:
+    - setGlobals:
+        jCustomerEnv: ${settings.jCustomerEnv}
+  - getJahiaVersion
+  - isVersionHigherOrEqual:
+      a: ${globals.jahiaVersion}
+      b: 8.0.0.0
+      res: jahia8
+  - if (${globals.jahia8}):
+    - removeKibanaAndJexperienceDashboards
+    - removeKibanaDashboardAccountsAndSpace:
+        jCustomerEnv: ${globals.jCustomerEnv}
   - removeAndCleanJexperience
-  - updateEnvLink
-  - refreshUnomiAllowedIPs:
-      unomiEnvName: ${globals.jCustomerEnv}
+  - updateEnvLinkJahia
+  - if ("${settings.isUnomiEnvDeletion.print()}" != "true"):
+    - updateEnvLinkJcustomer
+    - refreshUnomiAllowedIPs:
+        unomiEnvName: ${globals.jCustomerEnv}
 
 actions:
   getJcustomer:
@@ -33,10 +48,12 @@ actions:
     - setGlobals:
         jCustomerEnv: ${response.out}
 
-  updateEnvLink:
+  updateEnvLinkJahia:
     - environment.nodegroup.ApplyData [proc, cp]:
         data:
           envLink: null
+
+  updateEnvLinkJcustomer:
     - script: |
         const jahiaEnv = "${env.envName}";
         const jCustomerEnv = "${globals.jCustomerEnv}";
@@ -56,3 +73,17 @@ actions:
         }
         resp = jelastic.env.nodegroup.ApplyData(jCustomerEnv, session, nodeGroup='cp', data={'envLink': newEnvLink});
         return {"result": 0, "out": jahiaEnv + " removed from envLink of " + jCustomerEnv};
+
+settings:
+  fields:
+    - name: isUnomiEnvDeletion
+      type: radiolist
+      caption: Is the jCustomer env being deleted? (OPTIONAL, default value is false)
+      required: false
+      values:
+        true: Yes
+    - name: jCustomerEnv
+      type: envlist
+      caption: Linked jCustomer env (OPTIONAL, if not set then the envname will be retrieved)
+      required: false
+      valueField: shortdomain

--- a/packages/jahia/unlink-jahia-jcustomer.yml
+++ b/packages/jahia/unlink-jahia-jcustomer.yml
@@ -29,7 +29,7 @@ onInstall:
         jCustomerEnv: ${globals.jCustomerEnv}
   - removeAndCleanJexperience
   - updateEnvLinkJahia
-  - if ("${settings.isUnomiEnvDeletion.print()}" != "true"):
+  - if (! ${settings.isUnomiEnvDeletion}):
     - updateEnvLinkJcustomer
     - refreshUnomiAllowedIPs:
         unomiEnvName: ${globals.jCustomerEnv}
@@ -77,11 +77,10 @@ actions:
 settings:
   fields:
     - name: isUnomiEnvDeletion
-      type: radiolist
+      type: toggle
       caption: Is the jCustomer env being deleted? (OPTIONAL, default value is false)
       required: false
-      values:
-        true: Yes
+      value: false
     - name: jCustomerEnv
       type: envlist
       caption: Linked jCustomer env (OPTIONAL, if not set then the envname will be retrieved)

--- a/packages/jcustomer/update-events.yml
+++ b/packages/jcustomer/update-events.yml
@@ -55,8 +55,8 @@ onBeforeDelete:
       target: ${nodes.cp.first.id}
       title: "Deleting environment $envName"
       text: "$envName is going to be deleted"
-  - destroyESDeployment
   - deleteEnvLinkJcustomer
+  - destroyESDeployment
   - if ("${env.status}" == 1):
       - muteDatadogHost:
           target: "*"


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2064

Short description:
To avoid having a very complex `deleteEnvLinkJcustomer` action with many things to do on Jahia envs, I decided to update the unlink package so it can be used on each linked Jahia env when we delete a jCustomer env.
I feel like the code is clearer that way, and we avoid doing the same things in two different places, but let me know if it works for you @amitc-jahia and @laurentfufu 