### PR TITLE
PAAS-2210: fix datadog conf file when ampersand present in karaf password

### DIFF
--- a/mixins/jcustomer.yml
+++ b/mixins/jcustomer.yml
@@ -98,7 +98,7 @@ actions:
     - forEach(nodes.${this.target}):
         cmd[${@i.id}]: |-
           __secret__unomi_root_password_b64="${this.__secret__unomi_root_password_b64}"
-          sed -i "s/\(password: \).*/\1$(echo $__secret__unomi_root_password_b64 | base64 -d | sed 's;\\;\\\\;g')/" /etc/datadog-agent/conf.d/jmx.d/conf.yaml
+          sed -i "s/\(password: \).*/\1$(echo $__secret__unomi_root_password_b64 | base64 -d | sed 's;\([\\\&\$]\);\\\1;g')/" /etc/datadog-agent/conf.d/jmx.d/conf.yaml
           mkdir /etc/datadog-agent/conf.d/jelastic.d
           chown dd-agent: /etc/datadog-agent/conf.d/jelastic.d
           curl -fLSso /etc/datadog-agent/conf.d/jelastic.d/conf.yaml ${globals.repoRootUrl}/assets/common/dd_agent_jelastic_package_conf.yml || exit 1


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2210

Short description:
I don't really see the point of fixing this since the ampersand is a forbidden special character for karaf password (Jahia Cloud won't accept it) but this does the magic anyway