### PR TITLE
PAAS-2235: remove jexperience-dashboards and kibana-dashboards-provid…

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -1773,6 +1773,21 @@ actions:
     - environment.nodegroup.ApplyData [proc, cp]:
         data:
           envLink: null
+    - getJahiaVersion
+    - isVersionHigherOrEqual:
+        a: ${globals.jahiaVersion}
+        b: 8.0.0.0
+        res: jahia8
+    - if (${globals.jahia8}):
+        - cmd [proc]: |-
+            cfg_file=/data/digital-factory-data/karaf/etc/org.jahia.modules.kibana_dashboards_provider.cfg
+            sed -i "s,.*\(kibana_dashboards_provider.\)\(kibanaURL\|kibanaUser\|kibanaPassword\|kibanaSpace\).*,\1\2=,g" $cfg_file
+            sed -E 's:(^\s*kibana_dashboards_provider\.)(kibana(URL|User|Password|Space)).*:\1\2=:' -i $cfg_file
+        - uninstallModule:
+            moduleSymname: kibana-dashboards-provider
+        - uninstallModule:
+            moduleSymname: jexperience-dashboards
+
 
   getKibanaEndpointOfJcustomer:
     # Parameters:


### PR DESCRIPTION
…er modules  when restoring a backup having these modules on an environment that is not linked to a jcustomer

JIRA issue: https://jira.jahia.org/browse/PAAS-2235

Short description:
