### PR TITLE
Add restore-haproxy-config package

### DIFF
--- a/packages/jahia/restore-haproxy-config.yml
+++ b/packages/jahia/restore-haproxy-config.yml
@@ -1,0 +1,18 @@
+---
+type: update
+version: 1.5.2
+id: jahia-restore-haproxy-config
+name: Jahia restore HAProxy config
+description: Restores HAProxy config by making sure all backends are added and the healthcheck is enabled
+
+mixins:
+  - ../../mixins/common.yml
+  - ../../mixins/jahia.yml
+  - ../../mixins/haproxy.yml
+
+onInstall:
+  # Make sure all nodes are OK before restoring the config
+  - checkJahiaHealth: "cp, proc"
+  # Reset the config (backends list + healthcheck)
+  - resetHaproxyBackends
+  - enableHaproxyHealthcheck


### PR DESCRIPTION
Short description:
To be able to completely reset the HAProxy config, for instance in case a migration fails after disabling the healthcheck.