### PR TITLE
PAAS-2270: fix strongswan custom check after datadog-agent upgrade to v7

### DIFF
--- a/packages/jahia/migrations/migrate-to-v23.yaml
+++ b/packages/jahia/migrations/migrate-to-v23.yaml
@@ -69,6 +69,15 @@ actions:
       jps: "${baseUrl}../update-events.yml"
 
   updateDatadogAgent:
+    - cmd [cp, proc]: |-
+        check_filename=strongswan_connections_status.py
+        check_file=/etc/datadog-agent/checks.d/$check_filename
+        if ! (echo 88972f3df25145006bf5b05c5eb63cc8 $check_file | md5sum --status -c); then
+          curl -fLSso $check_file ${globals.repoRootUrl}/packages/jahia/migrations/v23_assets/$check_file || exit 1
+          chown dd-agent: $check_file
+        fi
+        pip install gnureadline
+      user: root
     - cmd[sqldb]: |-
         check_galera_wsrep_file=/etc/datadog-agent/checks.d/check_galera_wsrep_ready_status.py
         if ! (echo 2f116ff16890a9e9bb73109f2ec05e96 $check_galera_wsrep_file | md5sum --status -c); then
@@ -155,7 +164,7 @@ actions:
           )
           echo "probes.ModuleState.whitelist=$(echo ${modules[@]} | tr " " ",")" >> $sam_conf_file
         fi
-        
+
   updateHaproxyConf:
     - cmd[bl]: |-
         HAPROXY_DIR=/etc/haproxy

--- a/packages/jahia/migrations/v23_assets/strongswan_connections_status.py
+++ b/packages/jahia/migrations/v23_assets/strongswan_connections_status.py
@@ -1,0 +1,97 @@
+from os import system
+import subprocess
+import re
+
+# the following try/except block will make the custom check compatible with any Agent version
+try:
+    # first, try to import the base class from old versions of the Agent...
+    from checks import AgentCheck
+except ImportError:
+    # ...if the above failed, the check is running in Agent version 6 or later
+    from datadog_checks.base import AgentCheck
+
+__version__ = "1.0.0"
+
+
+class CheckStrongswanConnections(AgentCheck):
+
+    SERVICE_CHECK_NAME = "ipsec_status"
+    __NAMESPACE__ = "strongswan"
+    SYSTEMD_UNIT_NAME = 'strongswan'
+    CHECK_MESSAGES = {
+        "disabled": "Strongswan service is disabled, no ipsec connection to check.",
+        "established": "{} out of {} connection(s) is/are established.",
+        "inactive": "Strongswan service is enabled but not running.",
+        "not_established": "None of the {} connection(s) is/are not established.",
+    }
+
+    def check(self, instance):
+        try:
+            if not self.__checkServiceRunning():
+                return
+        except Exception:
+            message = "Can't get strongswan service status."
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=message)
+            return
+        try:
+            self.__checkConnections()
+        except Exception:
+            message = "Can't get strongswan connections status."
+            self.service_check(self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=message)
+            return
+
+    def __checkServiceRunning(self):
+        # If strongswan service is not enabled, it means there is no connection, so successful check
+        service_enabled = subprocess.run(
+            f'systemctl -q is-enabled {self.SYSTEMD_UNIT_NAME}',
+            shell=True,
+            capture_output=True
+        ).returncode
+        if service_enabled != 0:
+            self.service_check(
+                self.SERVICE_CHECK_NAME, AgentCheck.OK, message=self.CHECK_MESSAGES['disabled'])
+            return False
+        # If strongswan service is enabled but not active, it is a problem
+        service_active = subprocess.run(
+            f'systemctl -q is-active {self.SYSTEMD_UNIT_NAME}',
+            shell=True,
+            capture_output=True
+        ).returncode
+        if service_active != 0:
+            self.service_check(
+                self.SERVICE_CHECK_NAME, AgentCheck.CRITICAL, message=self.CHECK_MESSAGES['inactive'])
+            return False
+        return True
+
+    def __checkConnections(self):
+        # We get the status of all connections
+        strongswan_status = subprocess.run(
+            'sudo /usr/sbin/strongswan statusall',
+            shell=True,
+            capture_output=True
+        ).stdout.decode("utf-8")
+        r_existing = re.compile('.*child:.*TUNNEL.*')
+        r_established = re.compile('.*: ESTABLISHED.*')
+        # get uniq rightsubnet from existing routed list
+        # (we get uniq because if "HA"-like connections may exist
+        # with the same subnet as the main conections, so the HA connection
+        # is displayed as "routed" while not established)
+        subnets_set = set()
+        ip_regex = r"^.* === ((\d{1,3}\.){3}\d{1,3}/\d{1,2}) .*$"
+        for tunnel in re.findall(r_existing, strongswan_status):
+            subnets_set.add(re.search(ip_regex, tunnel).group(1))
+        conn_existing_num = len(subnets_set)
+        # Number of running connections
+        conn_established_num = len(re.findall(r_established, strongswan_status))
+        if conn_established_num:
+            self.service_check(
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.OK,
+                message=self.CHECK_MESSAGES['established'].format(conn_established_num, conn_existing_num)
+            )
+        else:
+            self.service_check(
+                self.SERVICE_CHECK_NAME,
+                AgentCheck.CRITICAL,
+                message=self.CHECK_MESSAGES['not_established'].format(conn_existing_num)
+            )


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2270

Short description:
The `strongswan_connections_status.py` script was not working anymore since we upgraded Datadog to v7 (we had bytes instead of a string when running the command `strongswan statusall`.

I also took advantage of this PR to install the package `gnureadline` to fix the Python3 shell (the arrows, tabulation and other keys wouldn't not behave as expected, making the usage of REPL very difficult)