### PR TITLE
PAAS-2300 add an ip denylist configuration

### DIFF
--- a/assets/haproxy/haproxy-jahia-cloud.cfg
+++ b/assets/haproxy/haproxy-jahia-cloud.cfg
@@ -65,6 +65,10 @@ frontend ft_http
     http-request capture req.fhdr(X-Forwarded-For) len 50
     http-request capture req.hdr(Host) len 50
 
+    #Blocking blackisted IPs
+    acl jahia_cloud_spamlist hdr_ip(X-Forwarded-For) -f /etc/haproxy/blacklisted_ips.txt
+    http-request tarpit if jahia_cloud_spamlist
+
     http-response set-header X-Content-Type-Options "nosniff"
     http-response set-header X-XSS-Protection "1; mode=block;"
 

--- a/mixins/haproxy.yml
+++ b/mixins/haproxy.yml
@@ -26,6 +26,7 @@ actions:
         HAPROXY_SERVICE_OVERRIDE=/etc/systemd/system/haproxy.service.d/override.conf
         HAPROXY_RELOAD=/usr/local/bin/haproxy-reload.sh
         mkdir $HAPROXY_CONF_DIR $HAPROXY_CONF_DIR/customer.configuration.d $HAPROXY_CONF_DIR/customer.errorpages.d
+        touch $HAPROXY_DIR/blacklisted_ips.txt
         curl -fLSso $HAPROXY_CONF_DIR/customer.errorpages.d/502.http ${globals.repoRootUrl}/assets/haproxy/502.http || exit 1
         curl -fLSso $HAPROXY_CONF_DIR/jahia-cloud.cfg ${globals.repoRootUrl}/assets/haproxy/haproxy-jahia-cloud.cfg || exit 1
         curl -fLSso $HAPROXY_CONF_DIR/http-errors.cfg ${globals.repoRootUrl}/assets/haproxy/http-errors.cfg || exit 1

--- a/packages/jahia/migrations/migrate-to-v24.yaml
+++ b/packages/jahia/migrations/migrate-to-v24.yaml
@@ -31,6 +31,8 @@ onInstall:
   - setGlobalRepoRootUrl
   ### End Pre-checks
 
+  - addIpDenyList                       # PAAS-2300
+
   # Actions that require a restart
   - removeInfoFromErrorPage             # PAAS-2332
 
@@ -71,3 +73,18 @@ actions:
     - if("${response.out}" == "restart"):
         - setGlobals:
             jahiaRollingRestartNeeded: true
+
+  addIpDenyList:
+    - cmd[bl]: |-
+        touch /etc/haproxy/blacklisted_ips.txt
+        chown haproxy: /etc/haproxy/blacklisted_ips.txt
+        if ! (grep -q "Blocking blackisted IPs" /etc/haproxy/haproxy.cfg.jahia/jahia-cloud.cfg); then
+          sed '67i\
+        \
+            #Blocking blackisted IPs\
+            acl jahia_cloud_spamlist hdr_ip(X-Forwarded-For) -f /etc/haproxy/blacklisted_ips.txt\
+            http-request tarpit if jahia_cloud_spamlist' \
+            -i /etc/haproxy/haproxy.cfg.jahia/jahia-cloud.cfg
+          systemctl reload haproxy || exit 1
+        fi
+      user: root


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2300

Short description:
since a production environment has a `/etc/haproxy/blacklisted_ips.txt` file used by a custom client configuration, i preferred to stick with this path and name for the file (although i would have preferred a non-racist name).
Another environment with a manually set up denylist also uses this same name. In addition, I have manually moved the configuration block within `jahia-cloud.cfg` to the same location.