### PR TITLE
PAAS-2372: update GraphQL to 2.18

### DIFF
--- a/packages/jahia/consistency-check.yml
+++ b/packages/jahia/consistency-check.yml
@@ -155,7 +155,7 @@ actions:
 
   checkGraphQL:
     # Jahia 8.0.3 ==> 2.6.0 (or above)
-    # Jahia [8.1.1.0;8.1.3.0] ==> 2.16.0 (or above)
+    # Jahia [8.1.1.0;8.1.5.0] ==> 2.18.0 (or above)
     - basicModuleCheck:
         moduleSymname: graphql-dxm-provider
     - if( "${globals.moduleState}" == "started" ):
@@ -170,12 +170,12 @@ actions:
                 lower: 8.1.1.0
                 lower_may_equal: true
                 version: ${globals.jahiaVersion}
-                higher: 8.1.3.0
+                higher: 8.1.5.0
                 higher_may_equal: true
                 res: isBetween8110and8130
-            - if( ${globals.isBetween8110and8130} ):
+            - if( ${globals.isBetween8110and8150} ):
                 - set:
-                    expectedVersion: 2.16.0
+                    expectedVersion: 2.18.0
         # Ugly workaround because ${fn.compare([globals.runningVersion], [this.expectedVersion])} doesn't work
         # see https://paas-support.virtuozzo.com/hc/en-us/requests/400488
         - set:

--- a/packages/jahia/migrations/migrate-to-v26.yaml
+++ b/packages/jahia/migrations/migrate-to-v26.yaml
@@ -31,6 +31,7 @@ onInstall:
   - upgradeSam                               # PAAS-2318
   - disableCloudModules                      # PAAS-2321
   - setNodeDistribution                      # PAAS-2291
+  - updateGraphQL                            # PAAS-2372
 
   # Actions that require a restart
 
@@ -137,6 +138,24 @@ actions:
               - az1: zoneA
                 az2: zoneB
                 az3: zoneC
+
+  updateGraphQL:
+    - getJahiaVersion
+    - isVersionBetween:
+        lower: 8.1.1.0
+        lower_may_equal: true
+        version: ${globals.jahiaVersion}
+        higher: 8.1.5.0
+        higher_may_equal: true
+        res: isBetween8110and8150
+    - if( ${globals.isBetween8110and8150} ):
+        - disableHaproxyHealthcheck  # upgrading graphql temporarily break the healthcheck
+        - installOrUpgradeModule:
+            moduleSymname: graphql-dxm-provider
+            moduleVersion: 2.18.0
+            moduleGroupId: org.jahia.modules
+            moduleRepository: jahia-releases
+        - enableHaproxyHealthcheck
 
 settings:
   fields:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2372

Short description: update GraphQL to 2.18. Upgrade consistency-check package to reflect the change.

