### PR TITLE
PAAS-2219: rollback tomcat version change

### DIFF
--- a/packages/jahia/migrations/migrate-to-v26.yaml
+++ b/packages/jahia/migrations/migrate-to-v26.yaml
@@ -40,7 +40,6 @@ onInstall:
   # Actions that require a restart
 
   # Actions that require a redeploy
-  - upgradeTomcat                            # PAAS-2219
 
   # Redeploy and restart actions:
   - if ("${globals.jahiaRollingRedeployNeeded}" == "true"):
@@ -116,13 +115,6 @@ actions:
                 moduleRepository: jahia-releases
             - checkJahiaHealth: "cp, proc"
             - enableHaproxyHealthcheck
-
-  upgradeTomcat:
-    - api: env.control.GetContainerEnvVars
-      nodeId: ${nodes.proc.first.id}
-    - if ("${response.object.TOMCAT_VERSION}" != "9.0.71"):
-        - setGlobals:
-            jahiaRollingRedeployNeeded: true
 
   disableCloudModules:
     cmd[cp, proc]: |-


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2219

Short description: rollback tomcat version switch in the last migration package. 
