### PR TITLE
PAAS-2447: Install Augmented Search 3.5.0 instead of 3.4.2

### DIFF
--- a/packages/jahia/augmented-search-install.yml
+++ b/packages/jahia/augmented-search-install.yml
@@ -53,7 +53,7 @@ actions:
         - setGlobals:
             db_connector_ver: 1.5.0
             es_connector_ver: 3.2.0
-            augsearch_ver: 3.4.2
+            augsearch_ver: 3.5.0
         - isVersionStrictlyLower:
             a: ${globals.jahiaVersion}
             b: 8.1.1.0


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2447