### PR TITLE
PAAS-2452: Install jExperience 2.7.1 instead of 2.6.0 for Jahia 8.1+ …

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -1771,7 +1771,7 @@ actions:
     # Get jExperience version to install according to Jahia / jCustomer env version:
     # - Jahia 7.3.x   ==> jExperience 1.11.9
     # - Jahia 8.0.x   ==> jExperience 2.2.0 & jExperienceDashboards 0.3.0
-    # - Jahia 8.1.x   ==> jExperience 2.6.0 & jExperienceDashboards 0.3.0
+    # - Jahia 8.1.x   ==> jExperience 2.7.1 & jExperienceDashboards 0.3.0
     # - jCustomer 2.x ==> jExperience 3.2.0 & jExperienceDashboards 1.0.0
     # Parameters:
     #   unomi_env_name: name of unomi environment
@@ -1798,7 +1798,7 @@ actions:
               jexperienceVersion: 2.2.0
       - else:
           - setGlobals:
-              jexperienceVersion: 2.6.0
+              jexperienceVersion: 2.7.1
     - api: env.control.GetContainerEnvVarsByGroup
       envName: ${this.unomi_env_name}
       nodeGroup: cp


### PR DESCRIPTION
…and jCustomer v1

JIRA issue: https://jira.jahia.org/browse/PAAS-2452

