### PR TITLE
PAAS-2449: add datadog config to storage nodes

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -259,6 +259,26 @@ actions:
         /usr/local/bin/set_dd_tags.sh
         systemctl restart crond
         systemctl enable datadog-agent
+    - if (nodes.sqldb.length == 1):
+        cmd[${this}]: |-
+          setfacl -m u:dd-agent:rx /var/log/messages
+          sed -i '/\/bin\/kill/a \        setfacl -m u:dd-agent:rx /var/log/messages' /etc/logrotate.d/syslog
+          cat > /etc/datadog-agent/conf.d/nfsstat.d/conf.yaml << EOF
+          init_config:
+          instances:
+            -
+              min_collection_interval: 60
+          logs:
+            - type: file
+              path: /var/log/messages
+              source: nfsstat
+              service: nfs
+              log_processing_rules:
+              - type: include_at_match
+                name: include_nfsstat_only
+                pattern: "nfsstat"
+          EOF
+          systemctl restart rsyslog crond datadog-agent
 
   startupJahiaHealthCheck:
     # Two arguments:
@@ -2059,3 +2079,49 @@ actions:
                   | jq -r '.data.admin.jahia.tasks | map(.name) | join(", ")' )
             echo $tasklist
         - log: "The node was stopped while these tasks were running: ${response.out}"
+
+  setupDatadogAgentStorage:
+    - log: "## Finalize Datadog agent setup on ${this}"
+    - setGlobalRepoRootUrl
+    - installLatestDatadogAgent: ${this}
+    - cmd[${this}]: |-
+        NODE_NAME=${HOSTNAME/-*}
+        echo "hostname: $(echo $_ROLE| sed 's/_//g').${NODE_NAME#node}" >> /etc/datadog-agent/datadog.yaml
+        sed -i 's/# logs_enabled: false/logs_enabled: true/' /etc/datadog-agent/datadog.yaml
+        echo "tags:" >> /etc/datadog-agent/datadog.yaml
+        echo " - product:jahia" >> /etc/datadog-agent/datadog.yaml
+        echo " - version:${DX_VERSION}" >> /etc/datadog-agent/datadog.yaml
+        echo " - envname:${env.envName}" >> /etc/datadog-agent/datadog.yaml
+        echo " - provide:${_PROVIDE}" >> /etc/datadog-agent/datadog.yaml
+        echo " - role:${_ROLE}" >> /etc/datadog-agent/datadog.yaml
+        curl -fLSso /usr/local/bin/set_dd_tags.sh ${globals.repoRootUrl}/assets/common/set_dd_tags.sh || exit 1
+        curl -fLSso /etc/cron.d/set_dd_tags_cron ${globals.repoRootUrl}/assets/common/set_dd_tags_cron || exit 1
+        chmod u+x /usr/local/bin/set_dd_tags.sh
+        if [[ $_ROLE == "glusterfs" ]]; then
+          echo "dd-agent ALL=(ALL) NOPASSWD:/opt/datadog-agent/embedded/sbin/gstatus" > /etc/sudoers.d/dd-agent
+          cat > /etc/datadog-agent/conf.d/glusterfs.d/conf.yaml << EOF
+        init_config:
+        instances:
+          -
+            min_collection_interval: 60
+        logs:
+          - type: file
+            path: /var/log/glusterfs/glusterd.log
+            source: glusterfs
+            service: glusterfs
+          - type: file
+            path: /var/log/glusterfs/glustershd.log
+            source: glusterfs
+            service: glusterfs
+          - type: file
+            path: /var/log/glusterfs/data.log
+            source: glusterfs
+            service: glusterfs
+        EOF
+          log_dir=/var/log/glusterfs
+          [ -d $log_dir ] || mkdir $log_dir
+          setfacl -m u:dd-agent:rx /var/log/glusterfs
+          setfacl -m u:dd-agent:rx /var/log/glusterfs/*.log
+          sed -i '/killall.*glusterd/a \  touch \/var\/log\/glusterfs\/glusterd.log && /usr\/bin\/setfacl -m u:dd-agent:rx \/var\/log\/glusterfs\/*.log' /etc/logrotate.d/glusterfs
+        fi
+        systemctl restart rsyslog crond datadog-agent

--- a/packages/jahia/install.yml
+++ b/packages/jahia/install.yml
@@ -12,7 +12,7 @@ description:
     needs for sustainable growth.
 
 globals:
-  jahia_env_version: 30
+  jahia_env_version: 31
   db_user: jahia-db-${fn.random}
   __secret__db_pass: ${fn.password(20)}
   __secret__db_user_datadog: ${fn.password(20)}
@@ -358,6 +358,7 @@ onInstall:
   - installPapiScript: bl, proc, cp, sqldb, storage
   - setupDatadogAgentSql: sqldb
   - setupDatadogAgentJahia: cp, proc
+  - setupDatadogAgentStorage: storage
   - setupDatadogAgentHaproxy: bl
   - setupRclone
   - setEnvVersion: ${globals.jahia_env_version}

--- a/packages/jahia/migrations/migrate-to-v31.yaml
+++ b/packages/jahia/migrations/migrate-to-v31.yaml
@@ -1,8 +1,8 @@
 ---
 type: update
 version: 1.5.2
-name: Migrate Jahia env to v30
-id: migrate-jahia-env-v30
+name: Migrate Jahia env to v31
+id: migrate-jahia-env-v31
 
 # Required for healthchecks
 mixins:
@@ -13,7 +13,7 @@ mixins:
   - "../../../mixins/elasticsearch.yml"
 
 globals:
-  version: 30
+  version: 31
 
 onInstall:
   ### Pre-migration actions
@@ -30,6 +30,7 @@ onInstall:
   # (None)
 
   - updateHaproxyReloadScript                 # PAAS-2514
+  - setupStorageMonitoring                    # PAAS-2449
 
   # Actions that require a restart
   # (None)
@@ -94,6 +95,38 @@ actions:
         curl -fLSso $file_path ${globals.repoRootUrl}/assets/haproxy/haproxy-reload.sh || exit 1
         chmod +x $file_path
       fi
+
+  setupStorageMonitoring:
+  - cmd [storage]: |-
+      file=/etc/datadog-agent/datadog.yaml
+      if [ ! -f $file ]; then
+        echo "need_install"
+      fi
+  - if ("${response.out}" == "need_install"):
+    - setupDatadogAgentStorage: storage
+  - if (nodes.sqldb.length == 1):
+      cmd[cp, proc]: |-
+        file=/etc/datadog-agent/conf.d/nfsstat.d/conf.yaml
+        if [ ! -f $file ]; then
+          setfacl -m u:dd-agent:rx /var/log/messages
+          sed -i '/\/bin\/kill/a \        setfacl -m u:dd-agent:rx /var/log/messages' /etc/logrotate.d/syslog
+          cat > $file << EOF
+        init_config:
+        instances:
+          -
+            min_collection_interval: 60
+        logs:
+          - type: file
+            path: /var/log/messages
+            source: nfsstat
+            service: nfs
+            log_processing_rules:
+            - type: include_at_match
+              name: include_nfsstat_only
+              pattern: "nfsstat"
+        EOF
+          systemctl restart rsyslog crond datadog-agent
+        fi
 
 settings:
   fields:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2449

Short description:
- Add "setupDatadogAgentStorage" action to Jahia install package.
- Add nfs monitoring on jahia nodes when needed.
