### PR TITLE
PAAS-2423: fix missing directory  mirror_folder when restoring backup

### DIFF
--- a/packages/common/restore.yml
+++ b/packages/common/restore.yml
@@ -460,7 +460,7 @@ actions:
 
         # reset the local mirror folder
         rm -fr $mirror_folder
-        mkdir $mirror_folder
+        mkdir -p $mirror_folder
 
         # download the datastore archive and extract it on the fly
         set -o pipefail


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2423

Short description:

**Don't forget** to update the README and any related documentation if needed: https://confluence.jahia.com/x/bYATAg
