### PR TITLE
PAAS-2412: add Let's Encrypt config

### DIFF
--- a/mixins/haproxy.yml
+++ b/mixins/haproxy.yml
@@ -8,6 +8,7 @@ globals:
 actions:
   installHaproxy:
     - retrieveHaproxyConf: bl
+    - addLetsEncryptConfig
     - updateHaproxyConf
     - configureProcessingDirectAccessHaproxy
     - resetHaproxyBackends
@@ -46,6 +47,11 @@ actions:
         - return:
             type: error
             message: "An error occurred while configuring haproxy."
+
+  addLetsEncryptConfig:
+    - cmd[bl]: |-
+        mkdir -p /var/lib/jelastic/keys/letsencrypt
+        echo "withExtIp=false" > /var/lib/jelastic/keys/letsencrypt/settings-custom
 
   updateHaproxyConf:
     - cmd[bl]: |-

--- a/packages/jahia/migrations/migrate-to-v31.yaml
+++ b/packages/jahia/migrations/migrate-to-v31.yaml
@@ -32,6 +32,7 @@ onInstall:
   - updateHaproxyReloadScript                 # PAAS-2514
   - updateHaproxyXforwadedForHeader           # PAAS-2552
   - setupStorageMonitoring                    # PAAS-2449
+  - addHaproxyLetsEncryptConfig               # PAAS-2412
 
   # Actions that require a restart
   - fixAPMMemoryLeak                          # PAAS-2449
@@ -165,6 +166,14 @@ actions:
     - if ("${response.out}" == "RESTART"):
         setGlobals:
           jahiaRollingRestartNeeded: true
+
+  addHaproxyLetsEncryptConfig:
+    - cmd[bl]: |-
+        file=/var/lib/jelastic/keys/letsencrypt/settings-custom
+        if [ ! -f $file ]; then
+          mkdir -p /var/lib/jelastic/keys/letsencrypt
+          echo "withExtIp=false" > $file
+        fi
 
 settings:
   fields:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2412

Short description: Add configuration on HAProxy nodes to allow Jelastic's LE add-on to work without an external IP.