### PR TITLE
PAAS-2689: add missing systemctl daemon-reload after adding datadog-agent override

### DIFF
--- a/mixins/common.yml
+++ b/mixins/common.yml
@@ -397,6 +397,7 @@ actions:
         chmod 755 $dd_agent_override_dir
         echo -e "[Service]\nEnvironmentFile=-/.jelenv" > $dd_agent_override_file
         chmod 644 $dd_agent_override_file
+        systemctl daemon-reload
     - configureDatadogSite:
         target: ${this}
 


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-XXX
