### PR TITLE
PAAS-2740: Install jExperience 2.9.0 instead of 2.8.0

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -1689,7 +1689,7 @@ actions:
   #######################
   getJexperienceVersion:
     # Get jExperience version to install according to jCustomer env version:
-    # - jCustomer 1.x ==> jExperience 2.8.0 & jExperienceDashboards 0.3.0
+    # - jCustomer 1.x ==> jExperience 2.9.0 & jExperienceDashboards 0.3.0
     # - jCustomer 2.x ==> jExperience 3.3.0 & jExperienceDashboards 1.0.0
     # Parameters:
     #   unomi_env_name: name of jCustomer environment
@@ -1711,7 +1711,7 @@ actions:
             jexperienceDashboardsVersion: 1.0.0
     - else:
         - setGlobals:
-            jexperienceVersion: 2.8.0
+            jexperienceVersion: 2.9.0
             jexperienceDashboardsVersion: 0.3.0
 
   getEnvLinkedJcustomer:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2740