### PR TITLE
PAAS-2658: add new checks for Jahia env disk space

### DIFF
--- a/assets/common/set_dd_tags.sh
+++ b/assets/common/set_dd_tags.sh
@@ -12,6 +12,7 @@ echo "api_key: $DATADOGAPIKEY"
 echo "hostname: $(echo $_ROLE| tr [A-Z] [a-z] |sed 's/_//g')."$(hostname | sed 's/^[[:alpha:]]\+\([[:digit:]]\+\).*/\1/' | tr [A-Z] [a-z])
 echo "site: ${DD_SITE}"
 echo "logs_enabled: true"
+echo "log_level: WARN"
 echo "logs_config:"
 echo "  processing_rules:"
 echo "    - type: mask_sequences"

--- a/assets/storage/storage_jahia_custom_metrics.py
+++ b/assets/storage/storage_jahia_custom_metrics.py
@@ -1,0 +1,38 @@
+import shutil
+import subprocess
+
+# the following try/except block will make the custom check compatible with any Agent version
+try:
+    # first, try to import the base class from old versions of the Agent...
+    from checks import AgentCheck
+except ImportError:
+    # ...if the above failed, the check is running in Agent version 6 or later
+    from datadog_checks.checks import AgentCheck
+
+__version__ = "1.0.0"
+
+
+class CheckCustomMetrics(AgentCheck):
+
+    __NAMESPACE__ = "jahia.custom_metrics"
+    DATASTORE_SIZE_METRIC_NAME = "customer_disk_usage.datastore"
+
+    def check(self, instance):
+        self.__get_datastore_size()
+
+    def __get_datastore_size(self):
+        df_size = shutil.disk_usage("/").used
+        try:
+            res = subprocess.run(
+                ["sudo", "du", "-bs", "/", "--exclude", "/data", "--exclude", "/glustervolume", "--exclude", "/proc"],
+                capture_output=True,
+                text=True,
+                check=True,
+            )
+        except subprocess.CalledProcessError as e:
+            self.log.error(f'{self.__NAMESPACE__}.{self.DATASTORE_SIZE_METRIC_NAME}: The "du" command failed, aborting. Error:\n{e.stderr}')
+            return
+
+        no_gluster_du_size = int(res.stdout.split("\t")[0])
+
+        self.gauge(self.DATASTORE_SIZE_METRIC_NAME, df_size - no_gluster_du_size)

--- a/assets/storage/storage_jahia_custom_metrics.yaml
+++ b/assets/storage/storage_jahia_custom_metrics.yaml
@@ -1,0 +1,3 @@
+init_config:
+instances:
+  - min_collection_interval: 3600

--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -1974,19 +1974,41 @@ actions:
     - setGlobalRepoRootUrl
     - installLatestDatadogAgent: ${this}
     - cmd[${this}]: |-
+        dd_dir=/etc/datadog-agent
+        dd_conf_file=$dd_dir/datadog.yaml
+        dd_checks_dir=$dd_dir/checks.d
+        custom_metrics_check_name=storage_jahia_custom_metrics
+        custom_metrics_check_dir=$dd_dir/conf.d/${custom_metrics_check_name}.d
         NODE_NAME=${HOSTNAME/-*}
-        echo "hostname: $(echo $_ROLE| sed 's/_//g').${NODE_NAME#node}" >> /etc/datadog-agent/datadog.yaml
-        sed -i 's/# logs_enabled: false/logs_enabled: true/' /etc/datadog-agent/datadog.yaml
-        echo "tags:" >> /etc/datadog-agent/datadog.yaml
-        echo " - product:jahia" >> /etc/datadog-agent/datadog.yaml
-        echo " - version:${DX_VERSION}" >> /etc/datadog-agent/datadog.yaml
-        echo " - envname:${env.envName}" >> /etc/datadog-agent/datadog.yaml
-        echo " - provide:${_PROVIDE}" >> /etc/datadog-agent/datadog.yaml
-        echo " - role:${_ROLE}" >> /etc/datadog-agent/datadog.yaml
+
+        echo "hostname: $(echo $_ROLE| sed 's/_//g').${NODE_NAME#node}" >> $dd_conf_file
+        sed -i 's/# logs_enabled: false/logs_enabled: true/' $dd_conf_file
+        echo "tags:" >> $dd_conf_file
+        echo " - product:jahia" >> $dd_conf_file
+        echo " - version:${DX_VERSION}" >> $dd_conf_file
+        echo " - envname:${env.envName}" >> $dd_conf_file
+        echo " - provide:${_PROVIDE}" >> $dd_conf_file
+        echo " - role:${_ROLE}" >> $dd_conf_file
+
         curl -fLSso /usr/local/bin/set_dd_tags.sh ${globals.repoRootUrl}/assets/common/set_dd_tags.sh || exit 1
         curl -fLSso /etc/cron.d/set_dd_tags_cron ${globals.repoRootUrl}/assets/common/set_dd_tags_cron || exit 1
         chmod u+x /usr/local/bin/set_dd_tags.sh
-    - if (nodes.sqldb.length > 1):
+
+        sed \
+            -e "/Cmnd_Alias JAHIA_MYSQL_SERVICE/a Cmnd_Alias JAHIA_DD_AGENT_CHECK = \/usr\/bin\/du" \
+            -e "/mysql ALL/a dd-agent ALL=NOPASSWD: JAHIA_DD_AGENT_CHECK" \
+            /etc/sudoers.d/jahia-rules
+
+        [ -d $custom_metrics_check_dir ] || mkdir $custom_metrics_check_dir
+        curl -fLSso $dd_checks_dir/${custom_metrics_check_name}.py ${globals.repoRootUrl}/assets/storage/${custom_metrics_check_name}.py || exit 1
+        curl -fLSso $custom_metrics_check_dir/${custom_metrics_check_name}.yaml-disabled ${globals.repoRootUrl}/assets/storage/${custom_metrics_check_name}.yaml || exit 1
+        chown dd-agent: -R $dd_checks_dir $custom_metrics_check_dir
+    - if ("${this}" == "${nodes.storage.first.id}") || ("${this}" == "storage"):
+        - cmd [${nodes.storage.first.id}]: |-
+            conf_file=/etc/datadog-agent/conf.d/storage_jahia_custom_metrics.d/storage_jahia_custom_metrics.yaml
+            [ -f $conf_file ] || mv ${conf_file}-disabled $conf_file
+            systemctl restart datadog-agent
+    - if (nodes.storage.length > 1):
         - forEach(nodes.storage):
             cmd[${@i.id}]: |-
               if [[ ${@i.id} = ${nodes.storage.first.id} ]]; then

--- a/packages/jahia/migrations/migrate-to-v38.yaml
+++ b/packages/jahia/migrations/migrate-to-v38.yaml
@@ -36,7 +36,7 @@ onInstall:
   - updateSendLogsCron                               # PAAS-2739
   - getLogEventScript: bl, proc, cp, sqldb, storage  # PAAS-2746 (action from mixins/common.yml)
   - updateCurl                                       # PAAS-2746
-  - addConsumptionMetricsCheck                       # PAAS-2678, PAAS-2688
+  - addConsumptionMetricsCheck                       # PAAS-2658, PAAS-2677, PAAS-2678, PAAS-2688
   - addTomcatTempCleanup                             # PAAS-2392
 
   # Actions that require a restart
@@ -218,6 +218,26 @@ actions:
         fi
 
         chown dd-agent: -R $dd_checks_dir $as_conf_dir $healthcheck_conf_dir $custom_metrics_conf_dir
+        systemctl restart datadog-agent
+    - cmd [storage]: |-
+        dd_dir=/etc/datadog-agent
+        dd_checks_dir=$dd_dir/checks.d
+        check_name=storage_jahia_custom_metrics
+        dd_conf_dir=$dd_dir/conf.d/${check_name}.d
+        sudoers=/etc/sudoers.d/jahia-rules
+
+        grep -q JAHIA_DD_AGENT_CHECK $sudoers || \
+          sed -e "/Cmnd_Alias JAHIA_MYSQL_SERVICE/a Cmnd_Alias JAHIA_DD_AGENT_CHECK = \/usr\/bin\/du" \
+              -e "/mysql ALL/a dd-agent ALL=NOPASSWD: JAHIA_DD_AGENT_CHECK" \
+              -i $sudoers
+
+        [ -d $dd_conf_dir ] || mkdir $dd_conf_dir
+        curl -fLSso $dd_checks_dir/${check_name}.py ${globals.repoRootUrl}/assets/storage/${check_name}.py || exit 1
+        curl -fLSso $dd_conf_dir/${check_name}.yaml-disabled ${globals.repoRootUrl}/assets/storage/${check_name}.yaml || exit 1
+        chown dd-agent: -R $dd_checks_dir $dd_conf_dir
+    - cmd [${nodes.storage.first.id}]: |-
+        conf_file=/etc/datadog-agent/conf.d/storage_jahia_custom_metrics.d/storage_jahia_custom_metrics.yaml
+        [ -f $conf_file ] || mv ${conf_file}-disabled $conf_file
         systemctl restart datadog-agent
 
   addTomcatTempCleanup:


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2658

Short description:
* I decided to add the AS indices check to the existing AS custom check to make things easier, and the datastore check needs to be run on a storage node
    * Since checks are not running on the same nodes, we can't have a single metric so I decided to a metric that will look like `jahia.custom_metrics.customer_disk_usage.<datastore|database|augmented_search>` and we will have to add the numbers in the widget.
* For the datastore check on storage nodes, I decided to give `dd-agent` the permission to run `sudo du`, the other option was to run the `du` command as a cron (run by root) and put the result in a file that can then be read by dd-agent. **If you prefer this solution** let me know and I will do the required changes
* I decided to go for Bytes and not Megabytes for all 3 metrics to avoid potential number/unit issues
* Last but not least, since the `jahia_custom_metrics` check runs every hour (as requested in PAAS-2677) so it means the database check will run every hour as well. I did the same thing for the datastore check but the AS indices check runs every 15s so this one will run much more often
    * Let me know if you want to change this