### PR TITLE
PAAS-2856: Add proxysql restart before tomcat starts

### DIFF
--- a/mixins/jahia.yml
+++ b/mixins/jahia.yml
@@ -149,6 +149,8 @@ actions:
     - cmd [proc]: |-
         file=/opt/tomcat/conf/digital-factory-config/jahia/applicationcontext-purge-jobs.xml
         mv ${file}-disabled $file
+    - cmd[proc, cp]: |-
+        systemctl restart proxysql
     - api: env.control.ExecDockerRunCmd
       nodeId: ${nodes.proc.first.id}
     - checkPatGroovyScriptExecution


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2856

Short description: Add proxysql restart before tomcat first start to make sure everything is in order.
