### PR TITLE
PAAS-3001: set tags before starting dd agent

### DIFF
--- a/mixins/jcustomer.yml
+++ b/mixins/jcustomer.yml
@@ -108,7 +108,13 @@ actions:
         if [ -f $file ]; then
           mv $file $file.disabled
         fi
-        systemctl restart datadog-agent
+        # Launch "set_dd_tags" script
+        output="$(/usr/local/bin/set_dd_tags.sh)"
+        # Force agent restart in case "set_dd_tags" didn't already do it
+        if [ "$output" = "Tags are up to date, exiting." ]; then
+          echo "Force datadog-agent restart"
+          systemctl restart datadog-agent
+        fi
     - cmd[${nodes.cp.first.id}]: |-
         file=/etc/datadog-agent/conf.d/jcustomer_custom_metrics.yaml
         if [ -f $file.disabled ]; then


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-3001

Short description: Run tag script before starting dd agent on jcustomer
