### PR TITLE
PAAS-2905: Do not run Datastore GC during migration

### DIFF
--- a/packages/jahia/migrations/migrate-to-v41.yaml
+++ b/packages/jahia/migrations/migrate-to-v41.yaml
@@ -169,8 +169,6 @@ actions:
         - switchDatastoreGarbageCollectionToTimer
         - api: environment.control.RestartNodeById
           nodeId: ${nodes.proc.first.id}
-        - cmd[proc]: |-
-            systemctl start run_datastore_gc
 
   updateJahiaOverride:
     - cmd[cp, proc]: |-


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2905