### PR TITLE
PAAS-3003: Use provisioning API when setting up Augmented Search

### DIFF
--- a/packages/jahia/augmented-search-install.yml
+++ b/packages/jahia/augmented-search-install.yml
@@ -63,13 +63,19 @@ actions:
           augsearch: enable
 
   setupAugSearch:
-    - cmd[proc]: |-
-        augsearch_cfg="/data/digital-factory-data/karaf/etc/org.jahia.modules.augmentedsearch.cfg"
-        sed -r \
-          -e 's/^(org.jahia.modules.augmentedsearch.prefix\s*=\s*).*/\1as/' \
-          -e 's/^(org.jahia.modules.augmentedsearch.numberOf(Shard|Replica)s\s*=\s*).*/\11/' \
-          -e 's/^(org.jahia.modules.augmentedsearch.minHeapPerShardInMb\s*=\s*).*/\110/' \
-          -i $augsearch_cfg
+    - callProvisioningAPI:
+        target: proc
+        payload:
+          - editConfiguration: "org.jahia.modules.augmentedsearch"
+            properties:
+              org.jahia.modules.augmentedsearch.prefix: "as"
+              org.jahia.modules.augmentedsearch.numberOfShards: "1"
+              org.jahia.modules.augmentedsearch.numberOfReplicas: "1"
+              org.jahia.modules.augmentedsearch.minHeapPerShardInMb: "10"
+    - if (! ${globals.provisioning_api_call_success}):
+        return:
+        type: error
+        message: "Failed to update AS configuration"
 
   setupESConnector:
     - cmd[proc]: |-


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-3003

Short description: Use provisioning API to update configuration files when setting up Augmented Search in Jahia
