### PR TITLE
PAAS-2945: do not in clude core HNs in the same group for upgrades

### DIFF
--- a/README.md
+++ b/README.md
@@ -721,6 +721,20 @@ This is particularly useful before running the Hardware Node upgrade script.
 | _--papi-token_    | Papi admin token. Optional if the `PAPI_TOKEN` environment variable is defined            |
 | _--papi-hostname_ | Papi hostname. Optional if the `PAPI_HOSTNAME` environment variable is defined            |
 
+##### common/hn_nodes_list.py
+
+This script is used to list all the nodes running on a Hardware Node (not including VAP nodes).
+
+| parameter                           | comment                                                                                            |
+| ----------------------------------- | -------------------------------------------------------------------------------------------------- |
+| _--jelastic-hardware-node-hostname_ | The HN hostname. Optional if the `JELASTIC_HARDWARE_NODE_HOSTNAME` environment variable is defined |
+| _--juser_                           | The Jelastic admin user. Optional if the `JELASTIC_USER` environment variable is defined           |
+| _--jpassword_                       | The Jelastic user's password. Optional if the `JELASTIC_PASSWORD` environment variable is defined  |
+| _--jserver_                         | The Jelastic cluster's DNS. Optional if the `JELASTIC_SERVER` environment variable is defined      |
+| _--region_                          | The Jelastic region to check. Optional if the `JELASTIC_REGION` environment variable is defined    |
+| _--papi-token_                      | Papi admin token. Optional if the `PAPI_TOKEN` environment variable is defined                     |
+| _--papi-hostname_                   | Papi hostname. Optional if the `PAPI_HOSTNAME` environment variable is defined                     |
+
 ##### common/hn_upgrade.py.py
 
 This script prepares a Hardware Node to be upgraded. It does the following actions:
@@ -751,6 +765,24 @@ This script prepares a Hardware Node to be upgraded. It does the following actio
 | _--skip-stop_                       | If this parameter is set, the script won't check the cluster state nor stop nodes on the HN. It can't be used if --recover-state is not set                                                          |
 | _--stop_nodes_threads_nb_           | The number of environments processed in parallel when stopping nodes (default: 4)                                                                                                                    |
 | _--start_nodes_threads_nb_          | The number of environments processed in parallel when starting nodes (default: 2)                                                                                                                    |
+
+##### common/hn_upgrade_plan.py
+
+This script is used to return a list of groups containing HNs that can be upgraded synchronously because
+they host clustered nodes for Jahia/jCustomer environments and VAP nodes (core nodes, SLBs...).
+
+This is very useful to paralelize upgrade of all HNs from a same region and save time since it's quite a
+long operation.
+
+| parameter               | comment                                                                                           |
+| ----------------------- | ------------------------------------------------------------------------------------------------- |
+| _--juser_               | The Jelastic admin user. Optional if the `JELASTIC_USER` environment variable is defined          |
+| _--jpassword_           | The Jelastic user's password. Optional if the `JELASTIC_PASSWORD` environment variable is defined |
+| _--jserver_             | The Jelastic cluster's DNS. Optional if the `JELASTIC_SERVER` environment variable is defined     |
+| _--region_              | The Jelastic region to check. Optional if the `JELASTIC_REGION` environment variable is defined   |
+| _--exclude_             | A comma separated list of HNs that should be excluded from the plan (optional)                    |
+| _--max-group-size_      | The maximum number of HNs per group, 0 to disable (optional, default value is 0)                  |
+| _--include-infra-nodes_ | To include INFRASTRUCTURE nodes to the groups (optional, default value is False)                  |
 
 ##### common/lib_aws.py
 

--- a/assets/common/hn_nodes_list.py
+++ b/assets/common/hn_nodes_list.py
@@ -11,7 +11,7 @@ from check_before_hn_upgrade import get_hardware_nodes, \
     get_jahia_cloud_envnames_from_papi
 from hn_upgrade import Hardware_node_upgrade
 
-logging.getLogger().setLevel(logging.WARN)
+logging.getLogger().setLevel(logging.INFO)
 
 RED_COLOR = "\033[0;31m"
 YELLOW_COLOR = "\033[0;33m"
@@ -92,7 +92,7 @@ def check_if_db_master_node(envname, node_index, jelastic_user_session):
         Return True if the db node is the current cluster "master", False otherwise
     """
     url = jelastic_user_session.hostname + "/1.0/environment/control/rest/execcmdbygroup"
-    command = "mysql -NB -u admin -p$(awk '$1=="password:" {print $2}' /etc/datadog-agent/conf.d/proxysql.d/conf.yaml) -P 6032 -h 127.0.0.1 " \
+    command = "mysql -NB -u admin -p$(awk '$1==\\\"password:\\\" {print $2}' /etc/datadog-agent/conf.d/proxysql.d/conf.yaml) -P 6032 -h 127.0.0.1 " \
               "-e \\\"SELECT hostname FROM runtime_mysql_servers ORDER BY weight DESC LIMIT 1\\\""
     params = {
         'session': jelastic_user_session.session,
@@ -146,7 +146,7 @@ def get_containers_infos_on_hn(
     organizations_envs = {}
     # The class is only used to get organization names so we only need to provide papi variables
     hn_upgrade = Hardware_node_upgrade(None, None, None, None, None, None, None, None, None, None,
-                                       papi_hostname, papi_token, False)
+                                       papi_hostname, papi_token, False, 0, 0)
     for container in hardware_node_containers:
         # Ignore weird jelastic containers
         if "envName" not in container or \


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-2945

Short description:
According to @Ronan-Gorain, it is not recommended by Virtuozzo to upgrade two or more HNs simultaneously so this PR might be useless if we stick to that (but it doesn't hurt to add a check regardless).
Regarding the SLBs, they are already included in the nodegroups we check to create the groups so nothing to add on this side