### PR TITLE
PAAS-3048 fix globals.galeraNodeNameIndex missing when redeploying si…

### DIFF
--- a/mixins/mariadb.yml
+++ b/mixins/mariadb.yml
@@ -429,6 +429,7 @@ actions:
             target: ${globals.origMasterId}
         - redeployGaleraNode: ${globals.origMasterId}
     - else:
+        - getGaleraNodeNameIndex: ${nodes.sqldb.first.id}
         - redeployGaleraNode: ${nodes.sqldb.first.id}
 
 


### PR DESCRIPTION
…ngledb

JIRA issue: https://jira.jahia.org/browse/PAAS-3048

Short description:

**Don't forget** to update the README and any related documentation if needed: https://confluence.jahia.com/x/bYATAg
