### PR TITLE
PAAS-3048: improve startup of MariaDB for single DB

### DIFF
--- a/mixins/mariadb.yml
+++ b/mixins/mariadb.yml
@@ -80,6 +80,7 @@ actions:
     - disablePhpMyAdmin: ${this}
     - cmd [${this}]: |-
         curl --retry 6 -fLSso /etc/logrotate.d/mysql ${globals.repoRootUrl}/assets/database/logrotate_mysql || exit 1
+        chmod 644 /etc/logrotate.d/mysql
         chown -R mysql:mysql /var/lib/jelastic/customizations
         logrotate -f /etc/logrotate.d/mysql
         systemctl enable --now mariadb
@@ -307,29 +308,32 @@ actions:
 
   startGaleraNode:
     - cmd [${this}]: |-
-        systemctl start mariadb 2>/dev/null
-        if [ ! -f /var/lib/mysql/grastate.dat ]; then
-          echo "$HOSTNAME is not in a cluster, nothing to do"
-          exit 0
+        if [ -f /var/lib/mysql/grastate.dat ]; then
+          # for Galera clusters, the startup of MariaDB can take a long time if the node is not safe to bootstrap and there is a lot
+          # of data to be transferred with SSTs, so the `systemctl start` command might fail with error messages but MariaDB is actually
+          # still starting. Hence the redirect of stderr to `/dev/null` to avoid printing false errors.
+          systemctl start mariadb 2>/dev/null
+          i=1
+          it=66
+          until [ "$(mysql -Ns -e "show global status like 'wsrep_local_state_comment'" 2>/dev/null | awk '{print $NF}')" == "Synced"  ]; do
+            if [ $i -ge $it ]; then
+              echo "Too long to start, something is wrong here... EXITING"
+              exit 1
+            fi
+            # As long as there is a mariabackup command running, we don't increment the timeout count
+            if pgrep wsrep_sst_maria; then
+              echo "$(date) SSTs sync still in progress..."
+              sleep 5
+            else
+              echo "$(date) not ready yet (iteration $i/$it)"
+              ((i++))
+              sleep 1
+            fi
+          done
+          echo "Node $HOSTNAME is now Synced !"
+        else
+          systemctl start mariadb || exit 1
         fi
-        i=1
-        it=66
-        until [ "$(mysql -Ns -e "show global status like 'wsrep_local_state_comment'" 2>/dev/null | awk '{print $NF}')" == "Synced"  ]; do
-          if [ $i -ge $it ]; then
-            echo "Too long to start, something is wrong here... EXITING"
-            exit 1
-          fi
-          # As long as there is a mariabackup command running, we don't increment the timeout count
-          if pgrep wsrep_sst_maria; then
-            echo "$(date) SSTs sync still in progress..."
-            sleep 5
-          else
-            echo "$(date) not ready yet (iteration $i/$it)"
-            ((i++))
-            sleep 1
-          fi
-        done
-        echo "Node $HOSTNAME is now Synced !"
         # In case a backup from a previous minor MariaDB has just been restored, we run mariadb-upgrade
         mariadb-upgrade --check-if-upgrade-is-needed && mariadb-upgrade || exit 0
 

--- a/packages/common/restore.yml
+++ b/packages/common/restore.yml
@@ -983,6 +983,8 @@ actions:
         if (pgrep mysqld > /dev/null); then
           pkill -e -9 mysqld
         fi
+        xtrabackup_file=/var/lib/mysql/xtrabackup_galera_info
+        [ -f $xtrabackup_file ] && cp -a $xtrabackup_file /root
         rm -rf /var/lib/mysql/*
         mv database.tar /var/lib/mysql/
         cd /var/lib/mysql/
@@ -1014,14 +1016,18 @@ actions:
 
     - if (nodes.sqldb.length > 1):
         - cmd [sqldb]: |-
-            seqno=$(cat /var/lib/mysql/xtrabackup_galera_info|cut -d':' -f 2)
-            uuid=$(cat /var/lib/mysql/xtrabackup_galera_info|cut -d':' -f 1)
-            echo "# GALERA saved state" > /var/lib/mysql/grastate.dat
-            echo "version:           2.1" >> /var/lib/mysql/grastate.dat
-            echo "uuid:              $uuid" >> /var/lib/mysql/grastate.dat
-            echo "seqno:             $seqno" >> /var/lib/mysql/grastate.dat
-            echo "safe_to_bootstrap: 0" >> /var/lib/mysql/grastate.dat
-            chown mysql: /var/lib/mysql/grastate.dat
+            xtrabackup_file=/var/lib/mysql/xtrabackup_galera_info
+            grastate_file=/var/lib/mysql/grastate.dat
+            [ -f $xtrabackup_file ] || cp -a /root/xtrabackup_galera_info $xtrabackup_file
+            rm -f /root/xtrabackup_galera_info
+            seqno=$(cat $xtrabackup_file | cut -d':' -f 2)
+            uuid=$(cat $xtrabackup_file|cut -d':' -f 1)
+            echo "# GALERA saved state" > $grastate_file
+            echo "version:           2.1" >> $grastate_file
+            echo "uuid:              $uuid" >> $grastate_file
+            echo "seqno:             $seqno" >> $grastate_file
+            echo "safe_to_bootstrap: 0" >> $grastate_file
+            chown mysql: $grastate_file
         - cmd[${nodes.sqldb.master.id}]: |-
             sed -i "s/safe_to_bootstrap.*/safe_to_bootstrap: 1/" /var/lib/mysql/grastate.dat
         # We start the bootstrap node first to make sure the mariadb-upgrade command is run first


### PR DESCRIPTION
JIRA issue: https://jira.jahia.org/browse/PAAS-3048

Short description:
Nothing really blocker but these could lead to issues in a near future so better to fix it now (and very low impact)
- the restore of a single DB env to a galera cluster env doesn't work anymore because the `xtrabackup_galera_info` file doesn't exist when trying to create the `grastate.dat` file, which leads to missing info and MariaDB startup failing. It used to work with SystemV for some reason despite `grastate.dat` having missing values but it doesn't work anymore since we moved to SystemD so it needs to be addressed by saving the `xtrabackup_galera_info` file before purging the folder in case the backup doesn't include it
- the logrotate file won't be taken into account if permissions are not set to 644 after redeploy
- I improved the startup of MariaDB for single DB nodes to make sure that the action fails if MariaDB doesn't start, and to make sure that `mariadb-upgrade` is done even for single DB nodes (issue introduced in one of my previous PRs)
