### PR TITLE
Ninja: Loop on healthcheck after graphql update

### DIFF
--- a/packages/jahia/update-graphql-dxm-provider.yaml
+++ b/packages/jahia/update-graphql-dxm-provider.yaml
@@ -22,6 +22,8 @@ onInstall:
           modules: graphql-dxm-provider/${settings.targetVersion}
       - checkJahiaHealth:
           target: "cp, proc"
+          singleCheck: false
+          timeout: 180
       - enableHaproxyHealthcheck
       - checkModule:
           moduleSymname: graphql-dxm-provider


### PR DESCRIPTION
Since updating graphql triggers a refresh of SAM module, which can take time, better take profit of the new options of `checkJahiaHealth` to loop instead of doing a single check that could fail