### PR TITLE
PAAS-3173: wait for jCustomer to actually restart before checking startup

### DIFF
--- a/packages/common/restore.yml
+++ b/packages/common/restore.yml
@@ -1104,6 +1104,7 @@ actions:
         - api: env.control.RestartNodes
           envName: ${env.envName}
           nodeGroup: cp
+        - sleep: 30000
     - else:
         log: "No env var backup available"
 


### PR DESCRIPTION
Short description:
There was an issue with Selenium tests because the PID changed during the startup check. This is because we check jCustomer startup right after restarting the nodes through an API call, and it can be too soon (jCustomer not done stopping yet) so the PID is the one before restart.
A 30s sleep should do the trick